### PR TITLE
Add exchangeratesapi.io support

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ end
   * Default: `CurrencyConversion.Source.Fixer`
   * Restrictions: Must implement `CurrencyConversion.Source` behaviour
   * Given Implementations:
-    - `CurrencyConversion.Source.Fixer` - Fixer IO
+    - `CurrencyConversion.Source.Fixer` - [Fixer](https://fixer.io/)
+    - `CurrencyConversion.Source.ExchangeRatesApi` - [Exchange Rates API](https://exchangeratesapi.io/)
     - `CurrencyConversion.Source.Test` - Test Source
 - `refresh_interval` - Configure how often the data should be refreshed. (in ms)
   * Type: `integer`

--- a/lib/currency_conversion/source/exchange_rates_api.ex
+++ b/lib/currency_conversion/source/exchange_rates_api.ex
@@ -32,9 +32,12 @@ defmodule CurrencyConversion.Source.ExchangeRatesApi do
   end
 
   defp parse(body) do
-    case Parser.parse(body) do
-      {:ok, data} -> interpret(data)
-      _ -> {:error, "JSON decoding of response body failed."}
+    try do
+      data = Parser.parse!(body, %{})
+      interpret(data)
+    rescue
+      Poison.ParseError ->
+        {:error, "JSON decoding of response body failed."}
     end
   end
 

--- a/lib/currency_conversion/source/exchange_rates_api.ex
+++ b/lib/currency_conversion/source/exchange_rates_api.ex
@@ -25,7 +25,7 @@ defmodule CurrencyConversion.Source.ExchangeRatesApi do
 
   """
   def load do
-    case HTTPotion.get(base_url(), query: %{access_key: get_access_key()}) do
+    case HTTPotion.get(base_url(), query: %{}) do
       %HTTPotion.Response{body: body, status_code: 200} -> parse(body)
       _ -> {:error, "Exchange Rates API unavailable."}
     end
@@ -65,8 +65,6 @@ defmodule CurrencyConversion.Source.ExchangeRatesApi do
   defp interpret_rates([], accumulator), do: {:ok, accumulator}
 
   defp base_url, do: get_protocol() <> "://" <> @base_endpoint
-
-  defp get_access_key, do: Application.get_env(:currency_conversion, :source_api_key)
 
   defp get_protocol,
     do: Application.get_env(:currency_conversion, :source_protocol, @default_protocol)

--- a/lib/currency_conversion/source/exchange_rates_api.ex
+++ b/lib/currency_conversion/source/exchange_rates_api.ex
@@ -1,0 +1,73 @@
+defmodule CurrencyConversion.Source.ExchangeRatesApi do
+  @moduledoc """
+  Currency Conversion Source for http://exchangeratesapi.io/
+  """
+
+  alias Poison.Parser
+
+  @behaviour CurrencyConversion.Source
+  @default_protocol "https"
+  @base_endpoint "api.exchangeratesapi.io/latest"
+  @doc """
+  Load current currency rates from exchangeratesapi.io.
+
+  ### Examples
+
+      iex> CurrencyConversion.Source.ExchangeRatesApi.load
+      {:ok, %CurrencyConversion.Rates{base: :EUR,
+        rates: %{AUD: 1.4205, BGN: 1.9558, BRL: 3.4093, CAD: 1.4048, CHF: 1.0693,
+         CNY: 7.3634, CZK: 27.021, DKK: 7.4367, GBP: 0.85143, HKD: 8.3006,
+         HRK: 7.48, HUF: 310.98, IDR: 14316.0, ILS: 4.0527, INR: 72.957,
+         JPY: 122.4, KRW: 1248.1, MXN: 22.476, MYR: 4.739, NOK: 8.9215,
+         NZD: 1.4793, PHP: 53.373, PLN: 4.3435, RON: 4.4943, RUB: 64.727,
+         SEK: 9.466, SGD: 1.5228, THB: 37.776, TRY: 4.1361, USD: 1.07,
+         ZAR: 14.31}}}
+
+  """
+  def load do
+    case HTTPotion.get(base_url(), query: %{access_key: get_access_key()}) do
+      %HTTPotion.Response{body: body, status_code: 200} -> parse(body)
+      _ -> {:error, "Exchange Rates API unavailable."}
+    end
+  end
+
+  defp parse(body) do
+    case Parser.parse(body) do
+      {:ok, data} -> interpret(data)
+      _ -> {:error, "JSON decoding of response body failed."}
+    end
+  end
+
+  defp interpret(%{"base" => base, "rates" => rates = %{}}) do
+    case interpret_rates(Map.to_list(rates)) do
+      {:ok, interpreted_rates} ->
+        {:ok,
+         %CurrencyConversion.Rates{
+           base: String.to_atom(base),
+           rates: interpreted_rates
+         }}
+
+      error ->
+        error
+    end
+  end
+
+  defp interpret(_data), do: {:error, "Exchange Rates API Schema has changed."}
+
+  defp interpret_rates(rates, accumulator \\ %{})
+
+  defp interpret_rates([{currency, rate} | tail], accumulator)
+       when is_binary(currency) and (is_float(rate) or is_integer(rate)) do
+    interpret_rates(tail, Map.put(accumulator, String.to_atom(currency), rate))
+  end
+
+  defp interpret_rates([_ | _], _), do: {:error, "Exchange Rates API Schema has changed."}
+  defp interpret_rates([], accumulator), do: {:ok, accumulator}
+
+  defp base_url, do: get_protocol() <> "://" <> @base_endpoint
+
+  defp get_access_key, do: Application.get_env(:currency_conversion, :source_api_key)
+
+  defp get_protocol,
+    do: Application.get_env(:currency_conversion, :source_protocol, @default_protocol)
+end

--- a/test/currency_conversion/source/exchange_rates_api_test.exs
+++ b/test/currency_conversion/source/exchange_rates_api_test.exs
@@ -1,5 +1,5 @@
 defmodule CurrencyConversion.Source.ExchangeRatesApiTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
   doctest CurrencyConversion.Source.ExchangeRatesApi, except: [load: 0]
 
   import CurrencyConversion.Source.ExchangeRatesApi

--- a/test/currency_conversion/source/exchange_rates_api_test.exs
+++ b/test/currency_conversion/source/exchange_rates_api_test.exs
@@ -1,0 +1,49 @@
+defmodule CurrencyConversion.Source.ExchangeRatesApiTest do
+  use ExUnit.Case, async: true
+  doctest CurrencyConversion.Source.ExchangeRatesApi, except: [load: 0]
+
+  import CurrencyConversion.Source.ExchangeRatesApi
+  import Mock
+
+  @not_200_response :something
+  test "load when status is not 200" do
+    with_mock HTTPotion, get: fn _url, _query -> @not_200_response end do
+      assert load() == {:error, "Exchange Rates API unavailable."}
+    end
+  end
+
+  @invalid_json_response %HTTPotion.Response{body: "not JSON", status_code: 200}
+  test "load when JSON is invalid" do
+    with_mock HTTPotion, get: fn _url, _query -> @invalid_json_response end do
+      assert load() == {:error, "JSON decoding of response body failed."}
+    end
+  end
+
+  @wrong_formatted_json [
+    %{"foo" => "bar"},
+    %{"base" => "CHF", "rates" => []},
+    %{"base" => "CHF", "rates" => %{"foo" => "string"}},
+    %{"base" => "CHF", "rates" => %{"foo" => :something}}
+  ]
+  for response <- @wrong_formatted_json do
+    @response response
+    test "load when JSON fomat is wrong with " <> inspect(response) do
+      with_mock HTTPotion,
+        get: fn _url, _query ->
+          %HTTPotion.Response{body: Poison.encode!(@response), status_code: 200}
+        end do
+        assert load() == {:error, "Exchange Rates API Schema has changed."}
+      end
+    end
+  end
+
+  @correctly_formatted_json %{"base" => "CHF", "rates" => %{"EUR" => 7.2}}
+  test "load correctly" do
+    with_mock HTTPotion,
+      get: fn _url, _query ->
+        %HTTPotion.Response{body: Poison.encode!(@correctly_formatted_json), status_code: 200}
+      end do
+      assert load() == {:ok, %CurrencyConversion.Rates{base: :CHF, rates: %{EUR: 7.2}}}
+    end
+  end
+end

--- a/test/currency_conversion/source/fixer_test.exs
+++ b/test/currency_conversion/source/fixer_test.exs
@@ -1,5 +1,5 @@
 defmodule CurrencyConversion.Source.FixerTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
   doctest CurrencyConversion.Source.Fixer, except: [load: 0]
 
   import CurrencyConversion.Source.Fixer


### PR DESCRIPTION
This should add support for exchangeratesapi free & open source service. It's based on Fixer API so most code is the same. However it's free service so there is no token and I felt it might be cleaner and better path for the future to have it separately rather then adjusting the Fixer file. What do you think?