### PR TITLE
Allow to request desired based currency

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ end
     - `CurrencyConversion.Source.Fixer` - [Fixer](https://fixer.io/)
     - `CurrencyConversion.Source.ExchangeRatesApi` - [Exchange Rates API](https://exchangeratesapi.io/)
     - `CurrencyConversion.Source.Test` - Test Source
+- `base_currency` - Change the base currency that is requested when fetching rates
+  * Type: `atom`
+  * Default: `:EUR`
 - `refresh_interval` - Configure how often the data should be refreshed. (in ms)
   * Type: `integer`
   * Default: `86_400_000` (Once per Day)

--- a/lib/currency_conversion/source/exchange_rates_api.ex
+++ b/lib/currency_conversion/source/exchange_rates_api.ex
@@ -8,6 +8,7 @@ defmodule CurrencyConversion.Source.ExchangeRatesApi do
   @behaviour CurrencyConversion.Source
   @default_protocol "https"
   @base_endpoint "api.exchangeratesapi.io/latest"
+  @default_base_currency :EUR
   @doc """
   Load current currency rates from exchangeratesapi.io.
 
@@ -25,7 +26,7 @@ defmodule CurrencyConversion.Source.ExchangeRatesApi do
 
   """
   def load do
-    case HTTPotion.get(base_url(), query: %{}) do
+    case HTTPotion.get(base_url(), query: %{base: get_base_currency()}) do
       %HTTPotion.Response{body: body, status_code: 200} -> parse(body)
       _ -> {:error, "Exchange Rates API unavailable."}
     end
@@ -71,4 +72,7 @@ defmodule CurrencyConversion.Source.ExchangeRatesApi do
 
   defp get_protocol,
     do: Application.get_env(:currency_conversion, :source_protocol, @default_protocol)
+
+  defp get_base_currency,
+    do: Application.get_env(:currency_conversion, :base_currency) || @default_base_currency
 end

--- a/lib/currency_conversion/source/exchange_rates_api.ex
+++ b/lib/currency_conversion/source/exchange_rates_api.ex
@@ -74,5 +74,5 @@ defmodule CurrencyConversion.Source.ExchangeRatesApi do
     do: Application.get_env(:currency_conversion, :source_protocol, @default_protocol)
 
   defp get_base_currency,
-    do: Application.get_env(:currency_conversion, :base_currency) || @default_base_currency
+    do: Application.get_env(:currency_conversion, :base_currency, @default_base_currency)
 end

--- a/lib/currency_conversion/source/fixer.ex
+++ b/lib/currency_conversion/source/fixer.ex
@@ -78,5 +78,5 @@ defmodule CurrencyConversion.Source.Fixer do
     do: Application.get_env(:currency_conversion, :source_protocol, @default_protocol)
 
   defp get_base_currency,
-    do: Application.get_env(:currency_conversion, :base_currency) || @default_base_currency
+    do: Application.get_env(:currency_conversion, :base_currency, @default_base_currency)
 end

--- a/lib/currency_conversion/source/fixer.ex
+++ b/lib/currency_conversion/source/fixer.ex
@@ -8,6 +8,7 @@ defmodule CurrencyConversion.Source.Fixer do
   @behaviour CurrencyConversion.Source
   @default_protocol "http"
   @base_endpoint "data.fixer.io/api/latest"
+  @default_base_currency :EUR
   @doc """
   Load current currency rates from fixer.io.
 
@@ -25,7 +26,9 @@ defmodule CurrencyConversion.Source.Fixer do
 
   """
   def load do
-    case HTTPotion.get(base_url(), query: %{access_key: get_access_key()}) do
+    case HTTPotion.get(base_url(),
+           query: %{base: get_base_currency(), access_key: get_access_key()}
+         ) do
       %HTTPotion.Response{body: body, status_code: 200} -> parse(body)
       _ -> {:error, "Fixer.io API unavailable."}
     end
@@ -73,4 +76,7 @@ defmodule CurrencyConversion.Source.Fixer do
 
   defp get_protocol,
     do: Application.get_env(:currency_conversion, :source_protocol, @default_protocol)
+
+  defp get_base_currency,
+    do: Application.get_env(:currency_conversion, :base_currency) || @default_base_currency
 end


### PR DESCRIPTION
I know this library converts any currency to any currency, but I also think it's nice to explicitly work with the base currency on the service/provider level to be a little bit more sure. So I am adding support for specifying a base currency to request from the given service. Of course it works without it as before by specifying `:EUR` as default (it's default for both services in reality).