### PR TITLE
Add ability to refresh rates manually

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,9 +60,10 @@ end
 - `base_currency` - Change the base currency that is requested when fetching rates
   * Type: `atom`
   * Default: `:EUR`
-- `refresh_interval` - Configure how often the data should be refreshed. (in ms)
-  * Type: `integer`
+- `refresh_interval` - Configure how often the data should be refreshed (in ms) or turn auto-refresh off.
+  * Type: `integer | atom`
   * Default: `86_400_000` (Once per Day)
+  * `:manual` turns auto-refresh off, do refresh yourself
 - `test_rates` - Configure rates for `CurrencyConversion.Source.Test` source
   * Type: `{atom, %{atom: float}}`
   * Default: see `CurrencyConversion.Source.Test.@default_rates`
@@ -95,11 +96,19 @@ config :my_app, MyApp.CurrencyConversion,
 
 ## Usage
 
-Only the function `CurrencyConversion.convert/3` is exposed to the user. The library [money](https://github.com/liuggio/money) is used to represent money amounts.
+Only the functions `CurrencyConversion.convert/3`, `CurrencyConversion.get_currencies/1`, and `CurrencyConversion.refresh_rates/0` are exposed to the user. The library [money](https://github.com/liuggio/money) is used to represent money amounts.
 
 ### Example
+
+Change 7 swiss franks to dollars:
 
 ```elixir
 iex> CurrencyConversion.convert(Money.new(7_00, :CHF), :USD)
 %Money{amount: 10_50, currency: :USD}
 ```
+
+Manually refresh exchange rates:
+
+```elixir
+iex> CurrencyConversion.refresh_rates()
+:ok

--- a/lib/currency_conversion.ex
+++ b/lib/currency_conversion.ex
@@ -86,13 +86,26 @@ defmodule CurrencyConversion do
 
       ### Examples
 
-          iex> CurrencyConversion.get_currencies()
+          iex> #{__MODULE__}.get_currencies()
           [:EUR, :CHF, :USD]
 
       """
       @impl unquote(__MODULE__)
       def get_currencies do
         unquote(__MODULE__).get_currencies(UpdateWorker.get_rates(@update_worker))
+      end
+
+      @doc """
+      Refresh exchange rates
+
+      ### Examples
+
+      iex> #{__MODULE__}.refresh_rates()
+      :ok
+      """
+      @spec refresh_rates() :: :ok | {:error, string}
+      def refresh_rates do
+        unquote(__MODULE__).refresh_rates(UpdateWorker.refresh_rates(@update_worker))
       end
     end
   end
@@ -125,4 +138,9 @@ defmodule CurrencyConversion do
   @doc false
   @spec get_currencies(rates :: Rates.t()) :: [atom]
   def get_currencies(%Rates{base: base, rates: rates}), do: [base | Map.keys(rates)]
+
+  @doc false
+  @spec refresh_rates(:ok | {:error, string}) :: :ok | {:error, string}
+  def refresh_rates(:ok), do: :ok
+  def refresh_rates({:error, error}), do: {:error, error}
 end

--- a/test/currency_conversion/update_worker_test.exs
+++ b/test/currency_conversion/update_worker_test.exs
@@ -56,4 +56,14 @@ defmodule CurrencyConversion.UpdateWorkerTest do
     assert_received :load
     assert_receive :load, 1_100
   end
+
+  test "manual refresh_inverval does not refresh", %{test: test_name} do
+    name = Module.concat(__MODULE__, test_name)
+
+    start_supervised!(
+      {UpdateWorker, source: Source, name: name, refresh_interval: :manual, caller_pid: self()}
+    )
+
+    refute_received :load
+  end
 end

--- a/test/currency_conversion_test.exs
+++ b/test/currency_conversion_test.exs
@@ -90,4 +90,10 @@ defmodule CurrencyConversionTest do
              ]
     end
   end
+
+  describe "refresh_rates/0" do
+    test "refreshes rates" do
+      assert Converter.refresh_rates() == :ok
+    end
+  end
 end


### PR DESCRIPTION
This:
- adds an option to turn off the auto-refresh
- exposes the update worker refresh ability as `refresh_rates()` function

This is also a pre-condition for #8 to have a more controlled process.
Note that the test is basic, but once we have an ability to load some currency state it will be easy to extend it and assert actual change.