### PR TITLE
Expose get_rates() function

### DIFF
--- a/lib/currency_conversion.ex
+++ b/lib/currency_conversion.ex
@@ -96,6 +96,55 @@ defmodule CurrencyConversion do
       end
 
       @doc """
+      Get current exchange rates
+
+      ### Examples
+
+          iex> #{__MODULE__}.get_rates()
+          %CurrencyConversion.Rates{
+              base: :EUR,
+              rates: %{
+                AUD: 1.4205,
+                BGN: 1.9558,
+                BRL: 3.4093,
+                CAD: 1.4048,
+                CHF: 1.0693,
+                CNY: 7.3634,
+                CZK: 27.021,
+                DKK: 7.4367,
+                GBP: 0.85143,
+                HKD: 8.3006,
+                HRK: 7.48,
+                HUF: 310.98,
+                IDR: 14316.0,
+                ILS: 4.0527,
+                INR: 72.957,
+                JPY: 122.4,
+                KRW: 1248.1,
+                MXN: 22.476,
+                MYR: 4.739,
+                NOK: 8.9215,
+                NZD: 1.4793,
+                PHP: 53.373,
+                PLN: 4.3435,
+                RON: 4.4943,
+                RUB: 64.727,
+                SEK: 9.466,
+                SGD: 1.5228,
+                THB: 37.776,
+                TRY: 4.1361,
+                USD: 1.07,
+                ZAR: 14.31
+              }
+            }
+
+      """
+      @impl unquote(__MODULE__)
+      def get_rates do
+        UpdateWorker.get_rates(@update_worker)
+      end
+
+      @doc """
       Refresh exchange rates
 
       ### Examples

--- a/test/currency_conversion_test.exs
+++ b/test/currency_conversion_test.exs
@@ -91,6 +91,47 @@ defmodule CurrencyConversionTest do
     end
   end
 
+  describe "get_rates/0" do
+    test "fetches current rates" do
+      assert Converter.get_rates() == %CurrencyConversion.Rates{
+               base: :EUR,
+               rates: %{
+                 AUD: 1.4205,
+                 BGN: 1.9558,
+                 BRL: 3.4093,
+                 CAD: 1.4048,
+                 CHF: 1.0693,
+                 CNY: 7.3634,
+                 CZK: 27.021,
+                 DKK: 7.4367,
+                 GBP: 0.85143,
+                 HKD: 8.3006,
+                 HRK: 7.48,
+                 HUF: 310.98,
+                 IDR: 14316.0,
+                 ILS: 4.0527,
+                 INR: 72.957,
+                 JPY: 122.4,
+                 KRW: 1248.1,
+                 MXN: 22.476,
+                 MYR: 4.739,
+                 NOK: 8.9215,
+                 NZD: 1.4793,
+                 PHP: 53.373,
+                 PLN: 4.3435,
+                 RON: 4.4943,
+                 RUB: 64.727,
+                 SEK: 9.466,
+                 SGD: 1.5228,
+                 THB: 37.776,
+                 TRY: 4.1361,
+                 USD: 1.07,
+                 ZAR: 14.31
+               }
+             }
+    end
+  end
+
   describe "refresh_rates/0" do
     test "refreshes rates" do
       assert Converter.refresh_rates() == :ok


### PR DESCRIPTION
This is necessary where we want to make sure we get the rates to be saved to DB without requesting them directly through the store itself (and therefore possibly get different data).