### PR TITLE
Accommodate for rates that are returned as integers and not floats

### DIFF
--- a/lib/currency_conversion/rates.ex
+++ b/lib/currency_conversion/rates.ex
@@ -28,13 +28,14 @@ defmodule CurrencyConversion.Rates do
   defstruct [:base, :rates]
 
   @doc false
-  @spec to_list(CurrencyConversion.Rates.t()) :: [{atom, float} | {:base, atom}]
+  @spec to_list(CurrencyConversion.Rates.t()) :: [{atom, float | integer()} | {:base, atom}]
   def to_list(%__MODULE__{base: base, rates: rates}) do
     [{:base, base} | Enum.to_list(rates)]
   end
 
   @doc false
-  @spec from_list(list :: [{atom, float} | {:base, atom}]) :: CurrencyConversion.Rates.t()
+  @spec from_list(list :: [{atom, float | integer()} | {:base, atom}]) ::
+          CurrencyConversion.Rates.t()
   def from_list(list) when is_list(list) do
     Enum.reduce(
       list,
@@ -44,7 +45,7 @@ defmodule CurrencyConversion.Rates do
           %__MODULE__{base: base, rates: rates}
 
         {currency, rate}, %__MODULE__{base: base, rates: rates}
-        when is_atom(currency) and is_float(rate) ->
+        when is_atom(currency) and (is_float(rate) or is_integer(rate)) ->
           %__MODULE__{base: base, rates: Map.put_new(rates, currency, rate)}
       end
     )

--- a/lib/currency_conversion/rates.ex
+++ b/lib/currency_conversion/rates.ex
@@ -5,7 +5,7 @@ defmodule CurrencyConversion.Rates do
 
   @type t :: %CurrencyConversion.Rates{
           base: atom,
-          rates: %{atom => float}
+          rates: %{atom => float | integer}
         }
 
   @doc """
@@ -28,13 +28,13 @@ defmodule CurrencyConversion.Rates do
   defstruct [:base, :rates]
 
   @doc false
-  @spec to_list(CurrencyConversion.Rates.t()) :: [{atom, float | integer()} | {:base, atom}]
+  @spec to_list(CurrencyConversion.Rates.t()) :: [{atom, float | integer} | {:base, atom}]
   def to_list(%__MODULE__{base: base, rates: rates}) do
     [{:base, base} | Enum.to_list(rates)]
   end
 
   @doc false
-  @spec from_list(list :: [{atom, float | integer()} | {:base, atom}]) ::
+  @spec from_list(list :: [{atom, float | integer} | {:base, atom}]) ::
           CurrencyConversion.Rates.t()
   def from_list(list) when is_list(list) do
     Enum.reduce(

--- a/test/currency_conversion_test.exs
+++ b/test/currency_conversion_test.exs
@@ -1,7 +1,7 @@
 defmodule CurrencyConversionTest do
   @moduledoc false
 
-  use ExUnit.Case, async: false
+  use ExUnit.Case, async: true
 
   doctest CurrencyConversion
 

--- a/test/currency_conversion_test.exs
+++ b/test/currency_conversion_test.exs
@@ -1,7 +1,7 @@
 defmodule CurrencyConversionTest do
   @moduledoc false
 
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
 
   doctest CurrencyConversion
 
@@ -35,6 +35,12 @@ defmodule CurrencyConversionTest do
     @tag test_rates: %CurrencyConversion.Rates{base: :EUR, rates: %{CHF: 0.5, USD: 0.75}}
     test "7.00 EUR => USD" do
       assert %Money{amount: 5_25, currency: :USD} = Converter.convert(Money.new(7_00, :EUR), :USD)
+    end
+
+    @tag test_rates: %CurrencyConversion.Rates{base: :EUR, rates: %{BIF: 1000}}
+    test "7.00 EUR => BIF" do
+      assert %Money{amount: 700_000, currency: :BIF} =
+               Converter.convert(Money.new(7_00, :EUR), :BIF)
     end
 
     @tag test_rates: %CurrencyConversion.Rates{base: :EUR, rates: %{CHF: 0.5, USD: 0.75}}


### PR DESCRIPTION
- Some currencies returns rates set in integer, and not float. For instance   {:BIF, 1920} was being returned in the fixer API, and would fail the rates from_list method as it fails the guard clauses in the anon function. 

`The following arguments were given to anonymous fn/2 in CurrencyConversion.Rates.from_list/1:
        # 1
        {:BIF, 1920}
        # 2
        %CurrencyConversion.Rates{
          base: nil,
          rates: %{
            BYN: 3.100701,
            AMD: 631.299859,
            CFK: 2381.486489,
            BRL: 6.488337....`

Example rates returned with the base as USD. There are rates being returned as integer. 
%CurrencyConversion.Rates{
  base: :USD,
  rates: %{
    SCR: 14.944904,
    GYD: 209.166443,
    TWD: 27.869301,
    BZD: 2.015232,
    MNT: 2850.652384,
    PLN: 3.768875,
    MYR: 4.102497,
    UAH: 27.748509,
    GBP: 0.717288,
    LBP: 1527.000189,
    CUC: 1,
    BAM: 1.613016,
    RON: 4.0647,
    TZS: 2318.495023,
    PEN: 3.792008,
    MVR: 15.402553,
    AMD: 520.62992,
    THB: 31.180232,
    AWG: 1.801,
    KHR: 4051.99976,
    IMP: 0.726375,
    KGS: 84.799905,
    SHP: 0.726375,
    ANG: 1.794528,
    VEF: 213830222338.07285,
    MOP: 7.993485,
    UYU: 44.054182,
    FJD: 2.049969,
    BHD: 0.376974,
    ISK: 122.94005,
    KYD: 0.833186,
    JOD: 0.708993,
    TTD: 6.785972,
    VND: 23055,
    CLP: 709.353992,
    HNL: 24.140048,
    EUR: 0.824903,
    BMD: 1,
    ALL: 101.625004,
    LYD: 4.469752,
    TND: 2.737497,
    MMK: 1557.12125,
    IQD: 1462.5,
    NIO: 35.150046,
    SRD: 14.154015,
    UZS: 10540.000473,
    MUR: 40.30235,
    BWP: 10.784989,
    ...
  }
}