### PR TITLE
Add a key to Exchange Rates API

### DIFF
--- a/lib/currency_conversion/source/exchange_rates_api.ex
+++ b/lib/currency_conversion/source/exchange_rates_api.ex
@@ -43,8 +43,9 @@ with {:module, _module} <- Code.ensure_compiled(Jason),
       base_currency = Keyword.get(opts, :base_currency, @default_base_currency)
       protocol = Keyword.get(opts, :source_protocol, @default_protocol)
       base_url = protocol <> "://" <> @base_endpoint
+      access_key = Keyword.fetch!(opts, :source_api_key)
 
-      case HTTPotion.get(base_url, query: %{base: base_currency}) do
+      case HTTPotion.get(base_url, query: %{base: base_currency, access_key: access_key}) do
         %HTTPotion.Response{body: body, status_code: 200} -> parse(body)
         _ -> {:error, "Exchange Rates API unavailable."}
       end

--- a/test/currency_conversion/source/exchange_rates_api_test.exs
+++ b/test/currency_conversion/source/exchange_rates_api_test.exs
@@ -49,4 +49,24 @@ defmodule CurrencyConversion.Source.ExchangeRatesApiTest do
       assert load([]) == {:ok, %CurrencyConversion.Rates{base: :CHF, rates: %{EUR: 7.2}}}
     end
   end
+
+  @error_json %{
+    "error" => %{
+      "code" => 101,
+      "info" =>
+        "You have not supplied a valid API Access Key. [Technical Support: support@apilayer.com]",
+      "type" => "invalid_access_key"
+    },
+    "success" => false
+  }
+  test "error yields" do
+    with_mock HTTPotion,
+      get: fn _url, _query ->
+        %HTTPotion.Response{body: Jason.encode!(@error_json), status_code: 200}
+      end do
+      assert load(source_api_key: "invalid") ==
+               {:error,
+                "Exchange Rates API Error: You have not supplied a valid API Access Key. [Technical Support: support@apilayer.com]."}
+    end
+  end
 end


### PR DESCRIPTION
The service cannot be used without API key anymore.

It's now basically the same thing as Fixer, although they have (very slightly) different pricelists.